### PR TITLE
Remove dependency on non-existant action job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   push:
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As the Github action for publishing was coppied from another project, it
still had a dependency on a job that no longer existed.

I've removed this dependency so that the action can be completed and the
project published to the docker hub.